### PR TITLE
Add Json type support

### DIFF
--- a/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
@@ -51,9 +51,9 @@ public class ExpandJsonFilterPlugin
 
         // check if a column specified as json_column_name option exists or not
         Column jsonColumn = inputSchema.lookupColumn(task.getJsonColumnName());
-        if (jsonColumn.getType() != Types.STRING) {
-            // throws ConfigException if the column is not string type.
-            throw new ConfigException(String.format("A column specified as json_column_name option must be string type: %s",
+        if (jsonColumn.getType() != Types.STRING && jsonColumn.getType() != Types.JSON) {
+            // throws ConfigException if the column is not string or json type.
+            throw new ConfigException(String.format("A column specified as json_column_name option must be string or json type: %s",
                     new Object[] {jsonColumn.toString()}));
         }
 


### PR DESCRIPTION
It allows users to
- Specify the name of Json typed column as 'json_column_name' option.
- Specify Json type as the types of columns declared in 'expanded_columns' option.
