### PR TITLE
Fix the behavior that the column specified as json_column_name has empty strings

### DIFF
--- a/src/main/java/org/embulk/filter/expand_json/FilteredPageOutput.java
+++ b/src/main/java/org/embulk/filter/expand_json/FilteredPageOutput.java
@@ -3,6 +3,7 @@ package org.embulk.filter.expand_json;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
+import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.jayway.jsonpath.Configuration;
@@ -266,14 +267,16 @@ public class FilteredPageOutput
         if (pageReader.isNull(jsonColumn)) {
             json = null;
         }
-        else if (jsonColumn.getType() == Types.JSON) {
-            // TODO could use Value object directly and optimize this code
-            String jsonObject = pageReader.getJson(jsonColumn).toJson();
-            json = parseContext.parse(jsonObject);
-        }
-        else { // Types.STRING
-            String jsonObject = pageReader.getString(jsonColumn);
-            json = parseContext.parse(jsonObject);
+        else {
+            String jsonObject;
+            if (jsonColumn.getType().equals(Types.JSON)) {
+                jsonObject = pageReader.getJson(jsonColumn).toJson(); // TODO could use Value object directly and optimize this code
+            }
+            else {
+                jsonObject = pageReader.getString(jsonColumn);
+            }
+
+            json = Strings.isNullOrEmpty(jsonObject) ? null : parseContext.parse(jsonObject);
         }
 
         for (ExpandedColumn expandedJsonColumn: expandedColumns) {


### PR DESCRIPTION
In the current implementation, if the column specified as json_column_name has empty string values, the following IllegalArgumentException occurs. This PR fixes this error. In the columns specified as expanded_columns, null values are inserted.

```
java.lang.IllegalArgumentException: json string can not be null or empty
    at com.jayway.jsonpath.internal.Utils.notEmpty(com/jayway/jsonpath/internal/Utils.java:386)
    at com.jayway.jsonpath.internal.JsonContext.parse(com/jayway/jsonpath/internal/JsonContext.java:81)
    at org.embulk.filter.expand_json.FilteredPageOutput.setExpandedJsonColumns(org/embulk/filter/expand_json/FilteredPageOutput.java:276)
    at org.embulk.filter.expand_json.FilteredPageOutput.add(org/embulk/filter/expand_json/FilteredPageOutput.java:209)
    at org.embulk.spi.PageBuilder.doFlush(org/embulk/spi/PageBuilder.java:229)
    at org.embulk.spi.PageBuilder.finish(org/embulk/spi/PageBuilder.java:243)
    at org.embulk.filter.expand_json.FilteredPageOutput.finish(org/embulk/filter/expand_json/FilteredPageOutput.java:223)
    at org.embulk.spi.PageBuilder.finish(org/embulk/spi/PageBuilder.java:244)
    at org.embulk.filter.expand_json.FilteredPageOutput.finish(org/embulk/filter/expand_json/FilteredPageOutput.java:223)
    at org.embulk.spi.PageBuilder.finish(org/embulk/spi/PageBuilder.java:244)
    at org.embulk.standards.JsonParserPlugin.run(org/embulk/standards/JsonParserPlugin.java:93)
... ...
```
