### PR TITLE
Add stop_on_invalid_record option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ expand columns having json into multiple columns
   - **name**: name of the column. you can define [JsonPath](http://goessner.net/articles/JsonPath/) style.
   - **type**: type of the column (see below)
   - **format**: format of the timestamp if type is timestamp
+- **stop_on_invalid_record**: Stop bulk load transaction if an invalid record is included (false by default)
 
 ---
 **type of the column**

--- a/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
@@ -41,6 +41,10 @@ public class ExpandJsonFilterPlugin
         @Config("time_zone")
         @ConfigDefault("\"UTC\"")
         public String getTimeZone();
+
+        @Config("stop_on_invalid_record")
+        @ConfigDefault("false")
+        boolean getStopOnInvalidRecord();
     }
 
     @Override


### PR DESCRIPTION
Add `stop_on_invalid_record` option
- This option is false by default.
- If the option is false, the plugin skips invalid records if it found them.
- If true, the plugin throws `DataException` if it found an invalid record. CsvParserPlugin also throws same exception. 
