### PR TITLE
Add validation for expanded_columns option

### DIFF
--- a/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
@@ -17,6 +17,7 @@ import org.embulk.spi.time.TimestampParser;
 import org.embulk.spi.type.Types;
 import org.slf4j.Logger;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ExpandJsonFilterPlugin
@@ -64,6 +65,7 @@ public class ExpandJsonFilterPlugin
             throw new ConfigException(String.format("A column specified as json_column_name option must be string or json type: %s",
                     new Object[] {jsonColumn.toString()}));
         }
+        validateExpandedColumns(task.getExpandedColumns());
 
         Schema outputSchema = buildOutputSchema(task, inputSchema);
         control.run(task.dump(), outputSchema);
@@ -124,4 +126,15 @@ public class ExpandJsonFilterPlugin
         return new Schema(builder.build());
     }
 
+    private void validateExpandedColumns(List<ColumnConfig> expandedColumns)
+    {
+        List<String> columnList = new ArrayList<>();
+        for (ColumnConfig columnConfig: expandedColumns) {
+            String columnName = columnConfig.getName();
+            if (columnList.contains(columnName)) {
+                throw new ConfigException(String.format("Column config for '%s' is duplicated at 'expanded_columns' option", columnName));
+            }
+            columnList.add(columnName);
+        }
+    }
 }

--- a/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
@@ -68,6 +68,7 @@ public class ExpandJsonFilterPlugin
         validateExpandedColumns(task.getExpandedColumns());
 
         Schema outputSchema = buildOutputSchema(task, inputSchema);
+        validateOutputSchema(outputSchema);
         control.run(task.dump(), outputSchema);
     }
 
@@ -133,6 +134,18 @@ public class ExpandJsonFilterPlugin
             String columnName = columnConfig.getName();
             if (columnList.contains(columnName)) {
                 throw new ConfigException(String.format("Column config for '%s' is duplicated at 'expanded_columns' option", columnName));
+            }
+            columnList.add(columnName);
+        }
+    }
+
+    private void validateOutputSchema(Schema outputSchema)
+    {
+        List<String> columnList = new ArrayList<>();
+        for (Column column: outputSchema.getColumns()) {
+            String columnName = column.getName();
+            if (columnList.contains(columnName)) {
+                throw new ConfigException(String.format("Output column '%s' is duplicated. Please check 'expanded_columns' option and Input plugin's settings.", columnName));
             }
             columnList.add(columnName);
         }

--- a/src/test/java/org/embulk/filter/expand_json/TestExpandJsonFilterPlugin.java
+++ b/src/test/java/org/embulk/filter/expand_json/TestExpandJsonFilterPlugin.java
@@ -165,6 +165,29 @@ public class TestExpandJsonFilterPlugin
     }
 
     @Test
+    public void testThrowExceptionDuplicatedExpandedColumns()
+    {
+        String configYaml = "" +
+                "type: expand_json\n" +
+                "json_column_name: _c0\n" +
+                "expanded_columns:\n" +
+                "  - {name: _c1, type: string}\n" +
+                "  - {name: _c1, type: string}";
+        ConfigSource config = getConfigFromYaml(configYaml);
+        schema = schema("_c0", STRING, "_c1", STRING);
+
+        exception.expect(ConfigException.class);
+        exception.expectMessage("Column config for '_c1' is duplicated at 'expanded_columns' option");
+        expandJsonFilterPlugin.transaction(config, schema, new Control() {
+            @Override
+            public void run(TaskSource taskSource, Schema schema)
+            {
+                // do nothing
+            }
+        });
+    }
+
+    @Test
     public void testDefaultValue()
     {
         String configYaml = "" +

--- a/src/test/java/org/embulk/filter/expand_json/TestExpandJsonFilterPlugin.java
+++ b/src/test/java/org/embulk/filter/expand_json/TestExpandJsonFilterPlugin.java
@@ -188,6 +188,28 @@ public class TestExpandJsonFilterPlugin
     }
 
     @Test
+    public void testThrowExceptionDuplicatedOutputColumns()
+    {
+        String configYaml = "" +
+                "type: expand_json\n" +
+                "json_column_name: _c0\n" +
+                "expanded_columns:\n" +
+                "  - {name: _c1, type: string}";
+        ConfigSource config = getConfigFromYaml(configYaml);
+        schema = schema("_c0", STRING, "_c0", STRING, "_c1", STRING);
+
+        exception.expect(ConfigException.class);
+        exception.expectMessage("Output column '_c1' is duplicated. Please check 'expanded_columns' option and Input plugin's settings.");
+        expandJsonFilterPlugin.transaction(config, schema, new Control() {
+            @Override
+            public void run(TaskSource taskSource, Schema schema)
+            {
+                // do nothing
+            }
+        });
+    }
+
+    @Test
     public void testDefaultValue()
     {
         String configYaml = "" +


### PR DESCRIPTION
I added validation for `expanded_columns` option to validate if duplicated column config is set.

``` yaml
filters:
  - type: expand_json
    ...
    expanded_columns:
      - {name: "phone_numbers", type: string}
      - {name: "phone_numbers", type: string}
```

``` shell
$ embulk run config.yml
...
Error: org.embulk.config.ConfigException: Column config for 'phone_numbers' is duplicated at 'expanded_columns' option
```

Embulk plugin should validate all config values at `transaction` method, and it should throw ConfigException or its subclass when validation fails.
