### PR TITLE
[Bugfix] Improve Exception handling

### DIFF
--- a/src/test/java/org/embulk/filter/expand_json/TestExpandJsonFilterPlugin.java
+++ b/src/test/java/org/embulk/filter/expand_json/TestExpandJsonFilterPlugin.java
@@ -455,6 +455,65 @@ public class TestExpandJsonFilterPlugin
         });
     }
 
+    @Test(expected = DataException.class)
+    public void testSetExpandedJsonColumnsSetInvalidDoubleValue()
+    {
+        setExpandedJsonColumnsWithInvalidValue("double", s("abcde"));
+    }
+
+    @Test(expected = DataException.class)
+    public void testSetExpandedJsonColumnsSetInvalidLongValue()
+    {
+        setExpandedJsonColumnsWithInvalidValue("long", s("abcde"));
+    }
+
+    @Test(expected = DataException.class)
+    public void testSetExpandedJsonColumnsSetInvalidTimestampValue()
+    {
+        setExpandedJsonColumnsWithInvalidValue("timestamp", s("abcde"));
+    }
+
+    @Test(expected = DataException.class)
+    public void testSetExpandedJsonColumnsSetInvalidJsonValue()
+    {
+        setExpandedJsonColumnsWithInvalidValue("json", s("abcde"));
+    }
+
+    public void setExpandedJsonColumnsWithInvalidValue(String ValidType, final Value invalidValue)
+    {
+        String configYaml = "" +
+                "type: expand_json\n" +
+                "stop_on_invalid_record: 1\n" +
+                "json_column_name: _c0\n" +
+                "root: $.\n" +
+                "time_zone: Asia/Tokyo\n" +
+                "expanded_columns:\n" +
+                "  - {name: _j0, type: " + ValidType + "}\n";
+
+        ConfigSource config = getConfigFromYaml(configYaml);
+        final Schema schema = schema("_c0", JSON, "_c1", STRING);
+
+        expandJsonFilterPlugin.transaction(config, schema, new Control()
+        {
+            @Override
+            public void run(TaskSource taskSource, Schema outputSchema)
+            {
+                MockPageOutput mockPageOutput = new MockPageOutput();
+                Value data = newMapBuilder()
+                        .put(s("_j0"), invalidValue)
+                        .build();
+
+                try (PageOutput pageOutput = expandJsonFilterPlugin.open(taskSource, schema, outputSchema, mockPageOutput)) {
+                    for (Page page : PageTestUtils.buildPage(runtime.getBufferAllocator(), schema, data, c1Data)) {
+                        pageOutput.add(page);
+                    }
+
+                    pageOutput.finish();
+                }
+            }
+        });
+    }
+
     @Test
     public void testExpandedJsonValuesWithKeepJsonColumns()
     {


### PR DESCRIPTION
Current implementation throws `NumberFormatException` if **long** value comes at column defined as **double** column.

In case of using Embulk from other program (e.g. EmbulkEmbed), program couldn't detect if Exception is a retryable Exception or not.  And program will retry infinitely.

I changed code to throw subclass of DataException if invalid value comes.
DataException and ConfigException isn't a retryable Exception at Embulk, so program will be able to stop retrying.
### Appendix

I tested with following config.yml and  TSV file.
##### config.yml

``` yaml
in:
  type: file
  path_prefix: /path/to/test.tsv
  parser:
    type: csv
    delimiter: "\t"
    skip_header_lines: 1
    columns:
    - {name: id, type: long}
    - {name: json, type: json}
filters:
  - type: expand_json
    json_column_name: json_payload
    stop_on_invalid_record: 1
    root: "$."
    expanded_columns:
      - {name: "string", type: string}
      - {name: "boolean", type: boolean}

      - {name: "double", type: long} # invalid (expected DataException)
      #- {name: "double", type: double} # valid

      - {name: "long", type: double} # invalid (expected DataException)
      #- {name: "long", type: long} # valid

      - {name: "timestamp", type: long} # invalid (expected DataException)
      #- {name: "timestamp", type: timestamp, format: "%Y-%m-%d %H:%M:%S"} # valid

      #- {name: "json", type: double} # invalid (expected DataException)
      - {name: "json", type: json} # valid
out:
  type: stdout
```
##### test.tsv

``` tsv
id  json_payload
1   {"string":"abcde","boolean":1,"double":1.23,"long":10023,"timestamp":"2015-10-07 20:23:57","json":{"k1":"v1"}}
2   {"string":"fghij","boolean":0,"double":312.5,"long":20000,"timestamp":"2015-11-17 11:31:12","json":{"k1":"v1"}}
3   {"string":"klmno","boolean":1,"double":3.1415,"long":31200,"timestamp":"2015-12-13 13:25:32","json":{"k2":1.23}}
4   {"string":"pqrst","boolean":1,"double":2.34,"long":51000,"timestamp":"2016-01-03 23:41:33","json":{"k2":3.14}}
5   {"string":"uvwxy","boolean":0,"double":5.12,"long":43000,"timestamp":"2016-03-15 12:11:05","json":{"k3":1}}
```
