### PR TITLE
Use default_timezone option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ expand columns having json into multiple columns
   - **type**: type of the column (see below)
   - **format**: format of the timestamp if type is timestamp
 - **keep_expanding_json_column**: Not remove the expanding json column from input schema if it's true (false by default)
+- **default_timezone**: Time zone of timestamp columns if values don’t include time zone description (`UTC` by default)
 - **stop_on_invalid_record**: Stop bulk load transaction if an invalid record is included (false by default)
 
 ---

--- a/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
@@ -38,11 +38,6 @@ public class ExpandJsonFilterPlugin
         @Config("expanded_columns")
         public List<ColumnConfig> getExpandedColumns();
 
-        @Config("time_zone")
-        @ConfigDefault("\"UTC\"")
-        @Deprecated
-        public String getTimeZone();
-
         // default_timezone option from TimestampParser.Task
 
         @Config("stop_on_invalid_record")
@@ -58,6 +53,11 @@ public class ExpandJsonFilterPlugin
     public void transaction(ConfigSource config, Schema inputSchema,
             FilterPlugin.Control control)
     {
+        // check if deprecated 'time_zone' option is used.
+        if (config.has("time_zone")) {
+            throw new ConfigException("'time_zone' option will be deprecated");
+        }
+
         PluginTask task = config.loadConfig(PluginTask.class);
 
         // check if a column specified as json_column_name option exists or not

--- a/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
@@ -38,10 +38,12 @@ public class ExpandJsonFilterPlugin
         @Config("expanded_columns")
         public List<ColumnConfig> getExpandedColumns();
 
-        // Time zone of timestamp columns if the value itself doesn’t include time zone description (eg. Asia/Tokyo)
         @Config("time_zone")
         @ConfigDefault("\"UTC\"")
+        @Deprecated
         public String getTimeZone();
+
+        // default_timezone option from TimestampParser.Task
 
         @Config("stop_on_invalid_record")
         @ConfigDefault("false")

--- a/src/main/java/org/embulk/filter/expand_json/FilteredPageOutput.java
+++ b/src/main/java/org/embulk/filter/expand_json/FilteredPageOutput.java
@@ -137,7 +137,7 @@ public class FilteredPageOutput
                         else {
                             format = task.getDefaultTimestampFormat();
                         }
-                        DateTimeZone timezone = DateTimeZone.forID(task.getTimeZone());
+                        final DateTimeZone timezone = task.getDefaultTimeZone();
                         timestampParser = new TimestampParser(task.getJRuby(), format, timezone);
                     }
 

--- a/src/test/java/org/embulk/filter/expand_json/TestExpandJsonFilterPlugin.java
+++ b/src/test/java/org/embulk/filter/expand_json/TestExpandJsonFilterPlugin.java
@@ -227,7 +227,7 @@ public class TestExpandJsonFilterPlugin
         PluginTask task = config.loadConfig(PluginTask.class);
 
         assertEquals("$.", task.getRoot());
-        assertEquals("UTC", task.getTimeZone());
+        assertEquals("UTC", task.getDefaultTimeZone().getID());
         assertEquals("%Y-%m-%d %H:%M:%S.%N %z", task.getDefaultTimestampFormat());
         assertEquals(false, task.getStopOnInvalidRecord());
         assertEquals(false, task.getKeepExpandingJsonColumn());
@@ -414,7 +414,7 @@ public class TestExpandJsonFilterPlugin
                 "type: expand_json\n" +
                 "json_column_name: _c0\n" +
                 "root: $.\n" +
-                "time_zone: Asia/Tokyo\n" +
+                "default_timezone: Asia/Tokyo\n" +
                 "expanded_columns:\n" +
                 "  - {name: _j0, type: boolean}\n" +
                 "  - {name: _j1, type: long}\n" +
@@ -531,7 +531,7 @@ public class TestExpandJsonFilterPlugin
                 "stop_on_invalid_record: 1\n" +
                 "json_column_name: _c0\n" +
                 "root: $.\n" +
-                "time_zone: Asia/Tokyo\n" +
+                "default_timezone: Asia/Tokyo\n" +
                 "expanded_columns:\n" +
                 "  - {name: _j0, type: " + ValidType + "}\n";
 
@@ -679,7 +679,7 @@ public class TestExpandJsonFilterPlugin
                 "type: expand_json\n" +
                 "json_column_name: _c0\n" +
                 "root: $.\n" +
-                "time_zone: Asia/Tokyo\n" +
+                "default_timezone: Asia/Tokyo\n" +
                 "expanded_columns:\n" +
                 "  - {name: _j0, type: boolean}\n" +
                 "  - {name: _j1, type: long}\n" +
@@ -863,7 +863,7 @@ public class TestExpandJsonFilterPlugin
                 "type: expand_json\n" +
                 "json_column_name: _c0\n" +
                 "root: $.\n" +
-                "time_zone: Asia/Tokyo\n" +
+                "default_timezone: Asia/Tokyo\n" +
                 "expanded_columns:\n" +
                 "  - {name: _j0, type: string}\n";
         ConfigSource config = getConfigFromYaml(configYaml);

--- a/src/test/java/org/embulk/filter/expand_json/TestExpandJsonFilterPlugin.java
+++ b/src/test/java/org/embulk/filter/expand_json/TestExpandJsonFilterPlugin.java
@@ -165,6 +165,26 @@ public class TestExpandJsonFilterPlugin
     }
 
     @Test
+    public void testThrowConfigExceptionIfTimeZoneIsUsed()
+    {
+        String configYaml = "" +
+                "type: expand_json\n" +
+                "time_zone: Asia/Tokyo\n";
+        ConfigSource config = getConfigFromYaml(configYaml);
+        schema = schema("_c0", STRING, "_c1", STRING);
+
+        exception.expect(ConfigException.class);
+        exception.expectMessage("'time_zone' option will be deprecated");
+        expandJsonFilterPlugin.transaction(config, schema, new Control() {
+            @Override
+            public void run(TaskSource taskSource, Schema schema)
+            {
+                // do nothing
+            }
+        });
+    }
+
+    @Test
     public void testThrowExceptionDuplicatedExpandedColumns()
     {
         String configYaml = "" +


### PR DESCRIPTION
As discussed about the usage of default_timezone option on https://github.com/civitaspo/embulk-filter-expand_json/issues/26, this PR enables default_timezone option instead of existing time_zone option. How about it?

Just in case, I didn't remove `getTimeZone` method in the PluginTask but, if you want to remove it, please let me know. 