### PR TITLE
Use host addon & Set `dist: precise`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: java
 jdk:
   - openjdk7
@@ -7,3 +8,7 @@ script:
   - ./gradlew test
 after_success:
   - ./gradlew jacocoTestReport coveralls
+addons:
+  hosts:
+    - me
+  hostname: me


### PR DESCRIPTION
Use host addon & Set `dist: precise` for fixing tests. See the below refs.

ref. https://blog.travis-ci.com/2017-08-31-trusty-as-default-status
ref. https://github.com/travis-ci/travis-ci/issues/5227#issuecomment-165131913
