### PR TITLE
A new feature: cache_provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ expand columns having json into multiple columns
 - **keep_expanding_json_column**: Not remove the expanding json column from input schema if it's true (false by default)
 - **default_timezone**: Time zone of timestamp columns if values don’t include time zone description (`UTC` by default)
 - **stop_on_invalid_record**: Stop bulk load transaction if an invalid record is included (false by default)
+- **cache_provider**: Cache provider name for JsonPath. `"LRU"` and `"NOOP"` are built-in. You can specify user defined class. (string, default: `"LRU"`)
 
 ---
 **type of the column**
@@ -53,6 +54,7 @@ filters:
       - {name: "profile.like_words[0]", type: string}
 ```
 
+
 ## Note
 - If the value evaluated by JsonPath is Array or Hash, the value is written as JSON.
 
@@ -61,11 +63,39 @@ filters:
   - use to evaluate [JsonPath](http://goessner.net/articles/JsonPath/)
   - [Apache License Version 2.0](https://github.com/jayway/JsonPath/blob/master/LICENSE)
 
+## Development
 
-## Build
+### Run Example
+
+```
+./gradlew classpath
+embulk run -Ilib ./example/config.yml
+```
+
+
+### Build
 
 ```
 $ ./gradlew gem  # -t to watch change of files and rebuild continuously
+```
+
+## Benchmark for `cache_provider` option
+
+In some cases, `cache_provider: NOOP` improves the performance of this plugin by 3 times (https://github.com/civitaspo/embulk-filter-expand_json/pull/41/).
+So we do a benchmark about `cache_provider`. In our case, `cache_provider: noop` improves the performance by 1.5 times.
+
+|use `expand_json` filter|cache_provider|Time took|records/s|
+|:---|:---|:---|:---|
+|`false`|none|7.62s|1,325,459/s|
+|`true`|`"LRU"`|2m9s|78,025/s|
+|`true`|`"NOOP"`|1m25s|118,476/s|
+
+
+You can reproduce the bench by the below way.
+
+```
+./gradlew classpath
+./bench/run.sh
 ```
 
 ## Contributor

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ expand columns having json into multiple columns
 - **default_timezone**: Time zone of timestamp columns if values don’t include time zone description (`UTC` by default)
 - **stop_on_invalid_record**: Stop bulk load transaction if an invalid record is included (false by default)
 - **cache_provider**: Cache provider name for JsonPath. `"LRU"` and `"NOOP"` are built-in. You can specify user defined class. (string, default: `"LRU"`)
+  - `"NOOP"` becomes default in the future.
 
 ---
 **type of the column**

--- a/bench/.bundle/config
+++ b/bench/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"

--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+*.jsonl

--- a/bench/Gemfile
+++ b/bench/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'embulk'
+gem 'embulk-parser-none'
+gem 'embulk-filter-speedometer'

--- a/bench/Gemfile.lock
+++ b/bench/Gemfile.lock
@@ -1,0 +1,22 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    embulk (0.9.16-java)
+      bundler (>= 1.10.6)
+      liquid (~> 4.0.0)
+      msgpack (~> 1.1.0)
+    embulk-filter-speedometer (0.3.4)
+    embulk-parser-none (0.2.0)
+    liquid (4.0.3)
+    msgpack (1.1.0-java)
+
+PLATFORMS
+  java
+
+DEPENDENCIES
+  embulk
+  embulk-filter-speedometer
+  embulk-parser-none
+
+BUNDLED WITH
+   1.16.0

--- a/bench/config_raw.yml
+++ b/bench/config_raw.yml
@@ -1,0 +1,14 @@
+in:
+  type: file
+  path_prefix: data.jsonl
+  parser:
+    type: none
+    column_name: payload
+
+filters:
+  - type: speedometer
+    log_interval_seconds: 1
+
+out:
+  type: "null"
+

--- a/bench/config_with_lru_cache.yml
+++ b/bench/config_with_lru_cache.yml
@@ -1,0 +1,27 @@
+in:
+  type: file
+  path_prefix: data.jsonl
+  parser:
+    type: none
+    column_name: payload
+
+filters:
+  - type: speedometer
+    log_interval_seconds: 1
+  - type: expand_json
+    json_column_name: payload
+    root: "$."
+    expanded_columns:
+      - {name: "phone_numbers", type: string}
+      - {name: "app_id", type: long}
+      - {name: "point", type: double}
+      - {name: "created_at", type: timestamp, format: "%Y-%m-%d"}
+      - {name: "profile.anniversary.et", type: string}
+      - {name: "profile.anniversary", type: string}
+      - {name: "profile.like_words[1]", type: string}
+      - {name: "profile.like_words[2]", type: string}
+      - {name: "profile.like_words", type: string}
+
+out:
+  type: "null"
+

--- a/bench/config_with_noop_cache.yml
+++ b/bench/config_with_noop_cache.yml
@@ -1,0 +1,28 @@
+in:
+  type: file
+  path_prefix: data.jsonl
+  parser:
+    type: none
+    column_name: payload
+
+filters:
+  - type: speedometer
+    log_interval_seconds: 1
+  - type: expand_json
+    json_column_name: payload
+    cache_provider: noop
+    root: "$."
+    expanded_columns:
+      - {name: "phone_numbers", type: string}
+      - {name: "app_id", type: long}
+      - {name: "point", type: double}
+      - {name: "created_at", type: timestamp, format: "%Y-%m-%d"}
+      - {name: "profile.anniversary.et", type: string}
+      - {name: "profile.anniversary", type: string}
+      - {name: "profile.like_words[1]", type: string}
+      - {name: "profile.like_words[2]", type: string}
+      - {name: "profile.like_words", type: string}
+
+out:
+  type: "null"
+

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+BENCH_ROOT=$(cd $(dirname $0); pwd)
+DATA_FILE=data.jsonl
+TMP_DATA_FILE=tmp.jsonl
+
+function now() {
+    date +"%FT%T%:z"
+}
+
+echo "[$(now)] Preparing ..."
+(
+    cd $BENCH_ROOT
+    embulk bundle
+
+    if [ -f $DATA_FILE ]; then
+        rm -f $DATA_FILE
+    fi
+    if [ -f $TMP_DATA_FILE ]; then
+        rm -f $TMP_DATA_FILE
+    fi
+    for n in {1..100}; do
+        cat ../example/data.tsv | cut -f5 >> $TMP_DATA_FILE
+    done
+    for n in {1..1000}; do
+        cat $TMP_DATA_FILE >> $DATA_FILE
+    done
+)
+
+echo "[$(now)] Run No expand_json"
+(
+    cd $BENCH_ROOT
+    time embulk run -I ../lib -b . config_raw.yml
+)
+
+echo "[$(now)] Run Default (LRUCache)"
+(
+    cd $BENCH_ROOT
+    time embulk run -I ../lib -b . config_with_lru_cache.yml
+)
+
+echo "[$(now)] Run with NOOPCache"
+(
+    cd $BENCH_ROOT
+    time embulk run -I ../lib -b . config_with_noop_cache.yml
+)
+
+echo "[$(now)] Teardown..."
+(
+    cd $BENCH_ROOT
+    if [ -f $DATA_FILE ]; then
+        rm -f $DATA_FILE
+    fi
+    if [ -f $TMP_DATA_FILE ]; then
+        rm -f $TMP_DATA_FILE
+    fi
+)

--- a/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
@@ -36,14 +36,14 @@ public class ExpandJsonFilterPlugin
             extends Task, TimestampParser.Task
     {
         @Config("json_column_name")
-        public String getJsonColumnName();
+        String getJsonColumnName();
 
         @Config("root")
         @ConfigDefault("\"$.\"")
-        public String getRoot();
+        String getRoot();
 
         @Config("expanded_columns")
-        public List<ColumnConfig> getExpandedColumns();
+        List<ColumnConfig> getExpandedColumns();
 
         // default_timezone option from TimestampParser.Task
 
@@ -53,11 +53,11 @@ public class ExpandJsonFilterPlugin
 
         @Config("keep_expanding_json_column")
         @ConfigDefault("false")
-        public boolean getKeepExpandingJsonColumn();
+        boolean getKeepExpandingJsonColumn();
 
         @Config("cache_provider")
         @ConfigDefault("null")
-        public Optional<String> getCacheProviderName();
+        Optional<String> getCacheProviderName();
     }
 
     @Override

--- a/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
@@ -1,6 +1,11 @@
 package org.embulk.filter.expand_json;
 
 import com.google.common.collect.ImmutableList;
+import com.jayway.jsonpath.JsonPathException;
+import com.jayway.jsonpath.spi.cache.Cache;
+import com.jayway.jsonpath.spi.cache.CacheProvider;
+import com.jayway.jsonpath.spi.cache.LRUCache;
+import com.jayway.jsonpath.spi.cache.NOOPCache;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigException;
@@ -19,6 +24,8 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 
 public class ExpandJsonFilterPlugin
         implements FilterPlugin
@@ -47,6 +54,10 @@ public class ExpandJsonFilterPlugin
         @Config("keep_expanding_json_column")
         @ConfigDefault("false")
         public boolean getKeepExpandingJsonColumn();
+
+        @Config("cache_provider")
+        @ConfigDefault("null")
+        public Optional<String> getCacheProviderName();
     }
 
     @Override
@@ -59,6 +70,9 @@ public class ExpandJsonFilterPlugin
         }
 
         PluginTask task = config.loadConfig(PluginTask.class);
+
+        // set cache provider
+        task.getCacheProviderName().ifPresent(this::setCacheProvider);
 
         // check if a column specified as json_column_name option exists or not
         Column jsonColumn = inputSchema.lookupColumn(task.getJsonColumnName());
@@ -79,6 +93,8 @@ public class ExpandJsonFilterPlugin
             final Schema outputSchema, final PageOutput output)
     {
         final PluginTask task = taskSource.loadTask(PluginTask.class);
+        // set cache provider for mapreduce executor.
+        task.getCacheProviderName().ifPresent(this::setCacheProviderOrIgnore);
         return new FilteredPageOutput(task, inputSchema, outputSchema, output);
     }
 
@@ -150,6 +166,41 @@ public class ExpandJsonFilterPlugin
                 throw new ConfigException(String.format("Output column '%s' is duplicated. Please check 'expanded_columns' option and Input plugin's settings.", columnName));
             }
             columnList.add(columnName);
+        }
+    }
+
+    private void setCacheProvider(String cacheProviderName)
+    {
+        String upperCacheProviderName = cacheProviderName.toUpperCase(Locale.ENGLISH);
+        switch (upperCacheProviderName)
+        {
+            case "LRU":
+                CacheProvider.setCache(new LRUCache(400));
+                break;
+
+            case "NOOP":
+                CacheProvider.setCache(new NOOPCache());
+                break;
+
+            default:
+                try {
+                    Class<?> klass = Class.forName(cacheProviderName);
+                    Cache cache = (Cache) klass.newInstance();
+                    CacheProvider.setCache(cache);
+                }
+                catch (ClassNotFoundException | IllegalAccessException | InstantiationException | ClassCastException e) {
+                    throw new ConfigException(String.format("Cache Provider %s is not supported: %s", cacheProviderName, e.getMessage()), e);
+                }
+        }
+    }
+
+    private void setCacheProviderOrIgnore(String cacheProviderName)
+    {
+        try {
+            setCacheProvider(cacheProviderName);
+        }
+        catch (JsonPathException e) {
+            logger.debug("Cache:{} is already set.", CacheProvider.getCache().getClass());
         }
     }
 }

--- a/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
@@ -189,7 +189,7 @@ public class ExpandJsonFilterPlugin
                     CacheProvider.setCache(cache);
                 }
                 catch (ClassNotFoundException | IllegalAccessException | InstantiationException | ClassCastException e) {
-                    throw new ConfigException(String.format("Cache Provider %s is not supported: %s", cacheProviderName, e.getMessage()), e);
+                    throw new ConfigException(String.format("Cache Provider '%s' is not supported: %s.", cacheProviderName, e.getMessage()), e);
                 }
         }
     }

--- a/src/main/java/org/embulk/filter/expand_json/FilteredPageOutput.java
+++ b/src/main/java/org/embulk/filter/expand_json/FilteredPageOutput.java
@@ -32,9 +32,6 @@ import java.util.Map;
 
 import static org.embulk.filter.expand_json.ExpandJsonFilterPlugin.PluginTask;
 
-/**
- * Created by takahiro.nakayama on 10/19/15.
- */
 public class FilteredPageOutput
     implements PageOutput
 {

--- a/src/test/java/org/embulk/filter/expand_json/MyNOOPCache.java
+++ b/src/test/java/org/embulk/filter/expand_json/MyNOOPCache.java
@@ -1,0 +1,9 @@
+package org.embulk.filter.expand_json;
+
+import com.jayway.jsonpath.spi.cache.NOOPCache;
+
+// This class is used for test: testUseUserDefiledCacheProvider
+public class MyNOOPCache
+        extends NOOPCache
+{
+}

--- a/src/test/java/org/embulk/filter/expand_json/TestExpandJsonFilterPlugin.java
+++ b/src/test/java/org/embulk/filter/expand_json/TestExpandJsonFilterPlugin.java
@@ -82,17 +82,21 @@ public class TestExpandJsonFilterPlugin
 
     @Before
     public void clearCacheProvider()
-            throws ClassNotFoundException, IllegalAccessException, NoSuchFieldException
     {
         // NOTE: CacheProvider has cache as private static variables,
         //       so clear the variables before tests run.
-        Class<?> klass = Class.forName(CacheProvider.class.getName());
-        Field cache = klass.getDeclaredField("cache");
-        cache.setAccessible(true);
-        cache.set(null, null);
-        Field cachingEnabled = klass.getDeclaredField("cachingEnabled");
-        cachingEnabled.setAccessible(true);
-        cachingEnabled.setBoolean(null, false);
+        try {
+            Class<?> klass = Class.forName(CacheProvider.class.getName());
+            Field cache = klass.getDeclaredField("cache");
+            cache.setAccessible(true);
+            cache.set(null, null);
+            Field cachingEnabled = klass.getDeclaredField("cachingEnabled");
+            cachingEnabled.setAccessible(true);
+            cachingEnabled.setBoolean(null, false);
+        }
+        catch (IllegalAccessException | NoSuchFieldException | ClassNotFoundException e) {
+            Throwables.propagate(e);
+        }
     }
 
     private ConfigSource getConfigFromYaml(String yaml)
@@ -447,7 +451,7 @@ public class TestExpandJsonFilterPlugin
                 fail();
             }
             catch (Throwable t) {
-                assertTrue(t instanceof DataException);
+                assertEquals(DataException.class, t.getClass());
             }
         }
     }
@@ -1093,6 +1097,761 @@ public class TestExpandJsonFilterPlugin
             }
         });
     }
+
+    // with NOOPCacheProvider
+    // NOTE: The below tests are the same as the above tests except 'cache_provider' setting.
+
+    @Test
+    public void testUnchangedColumnValuesWithNOOPCacheProvider()
+    {
+        String configYaml = "" +
+                "type: expand_json\n" +
+                "json_column_name: _c6\n" +
+                "root: $.\n" +
+                "cache_provider: noop\n" +
+                "expanded_columns:\n" +
+                "  - {name: _e0, type: string}\n";
+        final ConfigSource config = getConfigFromYaml(configYaml);
+        final Schema schema = schema("_c0", STRING, "_c1", BOOLEAN, "_c2", DOUBLE,
+                "_c3", LONG, "_c4", TIMESTAMP, "_c5", JSON, "_c6", STRING);
+
+        expandJsonFilterPlugin.transaction(config, schema, new Control()
+        {
+            @Override
+            public void run(TaskSource taskSource, Schema outputSchema)
+            {
+                MockPageOutput mockPageOutput = new MockPageOutput();
+
+                try (PageOutput pageOutput = expandJsonFilterPlugin.open(taskSource, schema, outputSchema, mockPageOutput)) {
+                    for (Page page : PageTestUtils.buildPage(runtime.getBufferAllocator(), schema,
+                            "_v0", // _c0
+                            true,  // _c1
+                            0.2, // _c2
+                            3L,   // _c3
+                            Timestamp.ofEpochSecond(4), // _c4
+                            newMapBuilder().put(s("_e0"), s("_v5")).build(), // _c5
+                            "{\"_e0\":\"_v6\"}")) {
+                        pageOutput.add(page);
+                    }
+
+                    pageOutput.finish();
+                }
+
+                List<Object[]> records = Pages.toObjects(outputSchema, mockPageOutput.pages);
+                assertEquals(1, records.size());
+
+                Object[] record = records.get(0);
+                assertEquals("_v0", record[0]);
+                assertEquals(true, record[1]);
+                assertEquals(0.2, (double) record[2], 0.0001);
+                assertEquals(3L, record[3]);
+                assertEquals(Timestamp.ofEpochSecond(4), record[4]);
+                assertEquals(newMapBuilder().put(s("_e0"), s("_v5")).build(), record[5]);
+            }
+        });
+    }
+
+    @Test
+    public void testStopOnInvalidRecordOptionWithNOOPCacheProvider()
+    {
+        String configYaml = "" +
+                "type: expand_json\n" +
+                "json_column_name: _c0\n" +
+                "root: $.\n" +
+                "cache_provider: noop\n" +
+                "expanded_columns:\n" +
+                "  - {name: _e0, type: json}\n";
+        final ConfigSource conf = getConfigFromYaml(configYaml);
+        final Schema schema = schema("_c0", STRING);
+
+        { // stop_on_invalid_record: false
+            ConfigSource config = conf.deepCopy();
+
+            expandJsonFilterPlugin.transaction(config, schema, new Control()
+            {
+                @Override
+                public void run(TaskSource taskSource, Schema outputSchema)
+                {
+                    MockPageOutput mockPageOutput = new MockPageOutput();
+
+                    try (PageOutput pageOutput = expandJsonFilterPlugin.open(taskSource, schema, outputSchema, mockPageOutput)) {
+                        for (Page page : PageTestUtils.buildPage(runtime.getBufferAllocator(), schema,
+                                "{\"_e0\":\"\"}", "{\"_e0\":{}}")) {
+                            pageOutput.add(page);
+                        }
+
+                        pageOutput.finish();
+                    }
+
+                    List<Object[]> records = Pages.toObjects(outputSchema, mockPageOutput.pages);
+                    assertEquals(1, records.size());
+                    assertEquals(0, ((MapValue) records.get(0)[0]).size()); // {}
+                }
+            });
+        }
+
+        // NOTE: CacheProvider is set the above test, so need to clear the CacheProvider before the below test.
+        clearCacheProvider();
+        { // stop_on_invalid_record: true
+            ConfigSource config = conf.deepCopy().set("stop_on_invalid_record", true);
+            try {
+                expandJsonFilterPlugin.transaction(config, schema, new Control()
+                {
+                    @Override
+                    public void run(TaskSource taskSource, Schema outputSchema)
+                    {
+                        MockPageOutput mockPageOutput = new MockPageOutput();
+
+                        try (PageOutput pageOutput = expandJsonFilterPlugin.open(taskSource, schema, outputSchema, mockPageOutput)) {
+                            for (Page page : PageTestUtils.buildPage(runtime.getBufferAllocator(), schema,
+                                    "{\"_e0\":\"\"}", "{\"_e0\":{}}")) {
+                                pageOutput.add(page);
+                            }
+
+                            pageOutput.finish();
+                        }
+                    }
+                });
+                fail();
+            }
+            catch (Throwable t) {
+                t.printStackTrace();
+                assertEquals(DataException.class, t.getClass());
+            }
+        }
+    }
+
+    @Test
+    public void testExpandJsonKeyToSchemaWithNOOPCacheProvider()
+    {
+        String configYaml = "" +
+                "type: expand_json\n" +
+                "json_column_name: _c0\n" +
+                "root: $.\n" +
+                "cache_provider: noop\n" +
+                "expanded_columns:\n" +
+                "  - {name: _j1, type: boolean}\n" +
+                "  - {name: _j2, type: long}\n" +
+                "  - {name: _j3, type: timestamp}\n" +
+                "  - {name: _j4, type: double}\n" +
+                "  - {name: _j5, type: string}\n" +
+                "  - {name: _j6, type: json}\n" +
+                "  - {name: _c0, type: string}\n";
+
+        ConfigSource config = getConfigFromYaml(configYaml);
+
+        expandJsonFilterPlugin.transaction(config, schema, new Control()
+        {
+            @Override
+            public void run(TaskSource taskSource, Schema outputSchema)
+            {
+                assertEquals(8, outputSchema.getColumnCount());
+
+                Column new_j1 = outputSchema.getColumn(0);
+                Column new_j2 = outputSchema.getColumn(1);
+                Column new_j3 = outputSchema.getColumn(2);
+                Column new_j4 = outputSchema.getColumn(3);
+                Column new_j5 = outputSchema.getColumn(4);
+                Column new_j6 = outputSchema.getColumn(5);
+                Column new_c0 = outputSchema.getColumn(6);
+                Column old_c1 = outputSchema.getColumn(7);
+
+                assertEquals("_j1", new_j1.getName());
+                assertEquals(BOOLEAN, new_j1.getType());
+                assertEquals("_j2", new_j2.getName());
+                assertEquals(LONG, new_j2.getType());
+                assertEquals("_j3", new_j3.getName());
+                assertEquals(TIMESTAMP, new_j3.getType());
+                assertEquals("_j4", new_j4.getName());
+                assertEquals(DOUBLE, new_j4.getType());
+                assertEquals("_j5", new_j5.getName());
+                assertEquals(STRING, new_j5.getType());
+                assertEquals("_j6", new_j6.getName());
+                assertEquals(JSON, new_j6.getType());
+                assertEquals("_c0", new_c0.getName());
+                assertEquals(STRING, new_c0.getType());
+                assertEquals("_c1", old_c1.getName());
+                assertEquals(STRING, old_c1.getType());
+            }
+        });
+    }
+
+    @Test
+    public void testColumnBasedTimezoneWithNOOPCacheProvider()
+    {
+        String configYaml = "" +
+                "type: expand_json\n" +
+                "json_column_name: _c0\n" +
+                "root: $.\n" +
+                "cache_provider: noop\n" +
+                "expanded_columns:\n" +
+                "  - {name: _j0, type: timestamp, format: '%Y-%m-%d %H:%M:%S %z'}\n" +
+                "  - {name: _j1, type: timestamp, format: '%Y-%m-%d %H:%M:%S', timezone: 'Asia/Tokyo'}\n";
+
+        ConfigSource config = getConfigFromYaml(configYaml);
+        final Schema schema = schema("_c0", JSON, "_c1", STRING);
+
+        expandJsonFilterPlugin.transaction(config, schema, new Control()
+        {
+            @Override
+            public void run(TaskSource taskSource, Schema outputSchema)
+            {
+                MockPageOutput mockPageOutput = new MockPageOutput();
+                Value data = newMapBuilder()
+                        .put(s("_j0"), s("2014-10-21 04:44:33 +0000"))
+                        .put(s("_j1"), s("2014-10-21 04:44:33"))
+                        .build();
+
+                try (PageOutput pageOutput = expandJsonFilterPlugin.open(taskSource, schema, outputSchema, mockPageOutput)) {
+                    for (Page page : PageTestUtils.buildPage(runtime.getBufferAllocator(), schema, data, c1Data)) {
+                        pageOutput.add(page);
+                    }
+
+                    pageOutput.finish();
+                }
+
+                PageReader pageReader = new PageReader(outputSchema);
+
+                for (Page page : mockPageOutput.pages) {
+                    pageReader.setPage(page);
+                    assertEquals("2014-10-21 04:44:33 UTC", pageReader.getTimestamp(outputSchema.getColumn(0)).toString());
+                    assertEquals("2014-10-20 19:44:33 UTC", pageReader.getTimestamp(outputSchema.getColumn(1)).toString());
+                    assertEquals(c1Data, pageReader.getString(outputSchema.getColumn(2)));
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testExpandJsonValuesFromJsonWithNOOPCacheProvider()
+    {
+        String configYaml = "" +
+                "type: expand_json\n" +
+                "json_column_name: _c0\n" +
+                "root: $.\n" +
+                "default_timezone: Asia/Tokyo\n" +
+                "cache_provider: noop\n" +
+                "expanded_columns:\n" +
+                "  - {name: _j0, type: boolean}\n" +
+                "  - {name: _j1, type: long}\n" +
+                "  - {name: _j2, type: timestamp, format: '%Y-%m-%d %H:%M:%S %z'}\n" +
+                "  - {name: _j3, type: double}\n" +
+                "  - {name: _j4, type: string}\n" +
+                "  - {name: _j5, type: timestamp, format: '%Y-%m-%d %H:%M:%S %z'}\n" +
+                "  - {name: _j6, type: timestamp, format: '%Y-%m-%d %H:%M:%S'}\n" +
+                // JsonPath: https://github.com/jayway/JsonPath
+                "  - {name: '_j7.store.book[*].author', type: string}\n" +
+                "  - {name: '_j7..book[?(@.price <= $[''_j7''][''expensive''])].author', type: string}\n" +
+                "  - {name: '_j7..book[?(@.isbn)]', type: string}\n" +
+                "  - {name: '_j7..book[?(@.author =~ /.*REES/i)].title', type: string}\n" +
+                "  - {name: '_j7.store.book[2].author', type: string}\n" +
+                "  - {name: _c0, type: string}\n";
+
+        ConfigSource config = getConfigFromYaml(configYaml);
+        final Schema schema = schema("_c0", JSON, "_c1", STRING);
+
+        expandJsonFilterPlugin.transaction(config, schema, new Control()
+        {
+            @Override
+            public void run(TaskSource taskSource, Schema outputSchema)
+            {
+                MockPageOutput mockPageOutput = new MockPageOutput();
+                Value data = newMapBuilder()
+                        .put(s("_j0"), b(true))
+                        .put(s("_j1"), i(2))
+                        .put(s("_j2"), s("2014-10-21 04:44:33 +0900"))
+                        .put(s("_j3"), f(4.4))
+                        .put(s("_j4"), s("v5"))
+                        .put(s("_j5"), s("2014-10-21 04:44:33 +0000"))
+                        .put(s("_j6"), s("2014-10-21 04:44:33"))
+                        .put(s("_j7"), newMapBuilder()
+                                .put(s("store"), newMapBuilder()
+                                        .put(s("book"), newArray(
+                                                newMap(s("author"), s("Nigel Rees"), s("title"), s("Sayings of the Century"), s("price"), f(8.95)),
+                                                newMap(s("author"), s("Evelyn Waugh"), s("title"), s("Sword of Honour"), s("price"), f(12.99)),
+                                                newMap(s("author"), s("Herman Melville"), s("title"), s("Moby Dick"), s("isbn"), s("0-553-21311-3"), s("price"), f(8.99)),
+                                                newMap(s("author"), s("J. R. R. Tolkien"), s("title"), s("The Lord of the Rings"), s("isbn"), s("0-395-19395-8"), s("price"), f(22.99))
+                                        ))
+                                        .put(s("bicycle"), newMap(s("color"), s("red"), s("price"), f(19.95)))
+                                        .build())
+                                .put(s("expensive"), i(10))
+                                .build())
+                        .put(s("_c0"), s("v12"))
+                        .build();
+
+                try (PageOutput pageOutput = expandJsonFilterPlugin.open(taskSource, schema, outputSchema, mockPageOutput)) {
+                    for (Page page : PageTestUtils.buildPage(runtime.getBufferAllocator(), schema, data, c1Data)) {
+                        pageOutput.add(page);
+                    }
+
+                    pageOutput.finish();
+                }
+
+                PageReader pageReader = new PageReader(outputSchema);
+
+                for (Page page : mockPageOutput.pages) {
+                    pageReader.setPage(page);
+                    assertEquals(true, pageReader.getBoolean(outputSchema.getColumn(0)));
+                    assertEquals(2, pageReader.getLong(outputSchema.getColumn(1)));
+                    assertEquals("2014-10-20 19:44:33 UTC", pageReader.getTimestamp(outputSchema.getColumn(2)).toString());
+                    assertEquals(String.valueOf(4.4), String.valueOf(pageReader.getDouble(outputSchema.getColumn(3))));
+                    assertEquals("v5", pageReader.getString(outputSchema.getColumn(4)));
+                    assertEquals("2014-10-21 04:44:33 UTC", pageReader.getTimestamp(outputSchema.getColumn(5)).toString());
+                    assertEquals("2014-10-20 19:44:33 UTC", pageReader.getTimestamp(outputSchema.getColumn(6)).toString());
+                    assertEquals("[\"Nigel Rees\",\"Evelyn Waugh\",\"Herman Melville\",\"J. R. R. Tolkien\"]",
+                            pageReader.getString(outputSchema.getColumn(7)));
+                    assertEquals("[\"Nigel Rees\",\"Herman Melville\"]", pageReader.getString(outputSchema.getColumn(8)));
+                    assertEquals("" +
+                                    "[" +
+                                    "{\"author\":\"Herman Melville\",\"title\":\"Moby Dick\",\"isbn\":\"0-553-21311-3\",\"price\":8.99}," +
+                                    "{\"author\":\"J. R. R. Tolkien\",\"title\":\"The Lord of the Rings\",\"isbn\":\"0-395-19395-8\",\"price\":22.99}" +
+                                    "]",
+                            pageReader.getString(outputSchema.getColumn(9)));
+                    assertEquals("[\"Sayings of the Century\"]", pageReader.getString(outputSchema.getColumn(10)));
+                    assertEquals("Herman Melville", pageReader.getString(outputSchema.getColumn(11)));
+                    assertEquals("v12", pageReader.getString(outputSchema.getColumn(12)));
+                    assertEquals(c1Data, pageReader.getString(outputSchema.getColumn(13)));
+                }
+            }
+        });
+    }
+
+    @Test(expected = DataException.class)
+    public void testSetExpandedJsonColumnsSetInvalidDoubleValueWithNOOPCacheProvider()
+    {
+        setExpandedJsonColumnsWithInvalidValueWithNOOPCacheProvider("double", s("abcde"));
+    }
+
+    @Test(expected = DataException.class)
+    public void testSetExpandedJsonColumnsSetInvalidLongValueWithNOOPCacheProvider()
+    {
+        setExpandedJsonColumnsWithInvalidValueWithNOOPCacheProvider("long", s("abcde"));
+    }
+
+    @Test(expected = DataException.class)
+    public void testSetExpandedJsonColumnsSetInvalidTimestampValueWithNOOPCacheProvider()
+    {
+        setExpandedJsonColumnsWithInvalidValueWithNOOPCacheProvider("timestamp", s("abcde"));
+    }
+
+    @Test(expected = DataException.class)
+    public void testSetExpandedJsonColumnsSetInvalidJsonValueWithNOOPCacheProvider()
+    {
+        setExpandedJsonColumnsWithInvalidValueWithNOOPCacheProvider("json", s("abcde"));
+    }
+
+    public void setExpandedJsonColumnsWithInvalidValueWithNOOPCacheProvider(String ValidType, final Value invalidValue)
+    {
+        String configYaml = "" +
+                "type: expand_json\n" +
+                "stop_on_invalid_record: 1\n" +
+                "json_column_name: _c0\n" +
+                "root: $.\n" +
+                "default_timezone: Asia/Tokyo\n" +
+                "cache_provider: noop\n" +
+                "expanded_columns:\n" +
+                "  - {name: _j0, type: " + ValidType + "}\n";
+
+        ConfigSource config = getConfigFromYaml(configYaml);
+        final Schema schema = schema("_c0", JSON, "_c1", STRING);
+
+        expandJsonFilterPlugin.transaction(config, schema, new Control()
+        {
+            @Override
+            public void run(TaskSource taskSource, Schema outputSchema)
+            {
+                MockPageOutput mockPageOutput = new MockPageOutput();
+                Value data = newMapBuilder()
+                        .put(s("_j0"), invalidValue)
+                        .build();
+
+                try (PageOutput pageOutput = expandJsonFilterPlugin.open(taskSource, schema, outputSchema, mockPageOutput)) {
+                    for (Page page : PageTestUtils.buildPage(runtime.getBufferAllocator(), schema, data, c1Data)) {
+                        pageOutput.add(page);
+                    }
+
+                    pageOutput.finish();
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testExpandedJsonValuesWithKeepJsonColumnsWithNOOPCacheProvider()
+    {
+        final String configYaml = "" +
+                "type: expand_json\n" +
+                "json_column_name: _c1\n" +
+                "root: $.\n" +
+                "cache_provider: noop\n" +
+                "expanded_columns:\n" +
+                "  - {name: _e0, type: string}\n" +
+                "keep_expanding_json_column: true\n";
+
+        ConfigSource config = getConfigFromYaml(configYaml);
+        final Schema schema = schema("_c0", STRING, "_c1", STRING);
+
+        expandJsonFilterPlugin.transaction(config, schema, new Control()
+        {
+            @Override
+            public void run(TaskSource taskSource, Schema outputSchema)
+            {
+                MockPageOutput mockPageOutput = new MockPageOutput();
+
+                try (PageOutput pageOutput = expandJsonFilterPlugin.open(taskSource, schema, outputSchema, mockPageOutput)) {
+                    for (Page page : PageTestUtils.buildPage(runtime.getBufferAllocator(), schema,
+                            "_v0", "{\"_e0\":\"_ev0\"}")) {
+                        pageOutput.add(page);
+                    }
+
+                    pageOutput.finish();
+                }
+
+                assertEquals(3, outputSchema.getColumnCount());
+                Column column;
+                { // 1st column
+                    column = outputSchema.getColumn(0);
+                    assertTrue(column.getName().equals("_c0") && column.getType().equals(STRING));
+                }
+                { // 2nd column
+                    column = outputSchema.getColumn(1);
+                    assertTrue(column.getName().equals("_c1") && column.getType().equals(STRING));
+                }
+                { // 3rd column
+                    column = outputSchema.getColumn(2);
+                    assertTrue(column.getName().equals("_e0") && column.getType().equals(STRING));
+                }
+
+                for (Object[] record : Pages.toObjects(outputSchema, mockPageOutput.pages)) {
+                    assertEquals("_v0", record[0]);
+                    assertEquals("{\"_e0\":\"_ev0\"}", record[1]);
+                    assertEquals("_ev0", record[2]);
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testExpandSpecialJsonValuesFromStringWithNOOPCacheProvider()
+    {
+        final String configYaml = "" +
+                "type: expand_json\n" +
+                "json_column_name: _c1\n" +
+                "root: $.\n" +
+                "cache_provider: noop\n" +
+                "expanded_columns:\n" +
+                "  - {name: _e0, type: string}\n" +
+                "  - {name: _e1, type: string}\n"; // the value will be null
+
+        ConfigSource config = getConfigFromYaml(configYaml);
+        final Schema schema = schema("_c0", STRING, "_c1", STRING);
+
+        expandJsonFilterPlugin.transaction(config, schema, new Control()
+        {
+            @Override
+            public void run(TaskSource taskSource, Schema outputSchema)
+            {
+                MockPageOutput mockPageOutput = new MockPageOutput();
+
+                try (PageOutput pageOutput = expandJsonFilterPlugin.open(taskSource, schema, outputSchema, mockPageOutput)) {
+                    for (Page page : PageTestUtils.buildPage(runtime.getBufferAllocator(), schema,
+                            "_v0", "")) {
+                        pageOutput.add(page);
+                    }
+
+                    pageOutput.finish();
+                }
+
+                for (Object[] record : Pages.toObjects(outputSchema, mockPageOutput.pages)) {
+                    assertEquals("_v0", record[0]);
+                    assertNull(record[1]);
+                    assertNull(record[2]);
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testExpandJsonValuesFromStringWithNOOPCacheProvider()
+    {
+        String configYaml = "" +
+                "type: expand_json\n" +
+                "json_column_name: _c0\n" +
+                "root: $.\n" +
+                "default_timezone: Asia/Tokyo\n" +
+                "cache_provider: noop\n" +
+                "expanded_columns:\n" +
+                "  - {name: _j0, type: boolean}\n" +
+                "  - {name: _j1, type: long}\n" +
+                "  - {name: _j2, type: timestamp, format: '%Y-%m-%d %H:%M:%S %z'}\n" +
+                "  - {name: _j3, type: double}\n" +
+                "  - {name: _j4, type: string}\n" +
+                "  - {name: _j5, type: timestamp, format: '%Y-%m-%d %H:%M:%S %z'}\n" +
+                "  - {name: _j6, type: timestamp, format: '%Y-%m-%d %H:%M:%S'}\n" +
+                // JsonPath: https://github.com/jayway/JsonPath
+                "  - {name: '_j7.store.book[*].author', type: string}\n" +
+                "  - {name: '_j7..book[?(@.price <= $[''_j7''][''expensive''])].author', type: string}\n" +
+                "  - {name: '_j7..book[?(@.isbn)]', type: string}\n" +
+                "  - {name: '_j7..book[?(@.author =~ /.*REES/i)].title', type: string}\n" +
+                "  - {name: '_j7.store.book[2].author', type: string}\n" +
+                "  - {name: _c0, type: string}\n";
+
+        ConfigSource config = getConfigFromYaml(configYaml);
+
+        expandJsonFilterPlugin.transaction(config, schema, new Control()
+        {
+            @Override
+            public void run(TaskSource taskSource, Schema outputSchema)
+            {
+                MockPageOutput mockPageOutput = new MockPageOutput();
+                PageOutput pageOutput = expandJsonFilterPlugin.open(taskSource,
+                        schema,
+                        outputSchema,
+                        mockPageOutput);
+
+                ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+                builder.put("_j0", true);
+                builder.put("_j1", 2);
+                builder.put("_j2", "2014-10-21 04:44:33 +0900");
+                builder.put("_j3", 4.4);
+                builder.put("_j4", "v5");
+                builder.put("_j5", "2014-10-21 04:44:33 +0000");
+                builder.put("_j6", "2014-10-21 04:44:33");
+                builder.put("_j7",
+                        ImmutableMap.of("store",
+                                ImmutableMap.of("book",
+                                        ImmutableList.of(ImmutableMap.of("author",
+                                                "Nigel Rees",
+                                                "title",
+                                                "Sayings of the Century",
+                                                "price",
+                                                8.95),
+                                                ImmutableMap.of("author",
+                                                        "Evelyn Waugh",
+                                                        "title",
+                                                        "Sword of Honour",
+                                                        "price",
+                                                        12.99),
+                                                ImmutableMap.of("author",
+                                                        "Herman Melville",
+                                                        "title",
+                                                        "Moby Dick",
+                                                        "isbn",
+                                                        "0-553-21311-3",
+                                                        "price",
+                                                        8.99),
+                                                ImmutableMap.of("author",
+                                                        "J. R. R. Tolkien",
+                                                        "title",
+                                                        "The Lord of the Rings",
+                                                        "isbn",
+                                                        "0-395-19395-8",
+                                                        "price",
+                                                        22.99)
+                                        ),
+                                        "bicycle",
+                                        ImmutableMap.of("color",
+                                                "red",
+                                                "price",
+                                                19.95
+                                        )
+                                ),
+                                "expensive",
+                                10
+                        )
+                            /*
+                            {
+                                "store": {
+                                    "book": [
+                                        {
+                                            "author": "Nigel Rees",
+                                            "title": "Sayings of the Century",
+                                            "price": 8.95
+                                        },
+                                        {
+                                            "author": "Evelyn Waugh",
+                                            "title": "Sword of Honour",
+                                            "price": 12.99
+                                        },
+                                        {
+                                            "author": "Herman Melville",
+                                            "title": "Moby Dick",
+                                            "isbn": "0-553-21311-3",
+                                            "price": 8.99
+                                        },
+                                        {
+                                            "author": "J. R. R. Tolkien",
+                                            "title": "The Lord of the Rings",
+                                            "isbn": "0-395-19395-8",
+                                            "price": 22.99
+                                        }
+                                    ],
+                                    "bicycle": {
+                                        "color": "red",
+                                        "price": 19.95
+                                    }
+                                },
+                                "expensive": 10
+                            }
+                             */
+                );
+                builder.put("_c0", "v12");
+
+                String data = convertToJsonString(builder.build());
+
+                for (Page page : PageTestUtils.buildPage(runtime.getBufferAllocator(),
+                        schema,
+                        data, c1Data)) {
+                    pageOutput.add(page);
+                }
+
+                pageOutput.finish();
+                pageOutput.close();
+
+                PageReader pageReader = new PageReader(outputSchema);
+
+                for (Page page : mockPageOutput.pages) {
+                    pageReader.setPage(page);
+                    assertEquals(true, pageReader.getBoolean(outputSchema.getColumn(0)));
+                    assertEquals(2, pageReader.getLong(outputSchema.getColumn(1)));
+                    assertEquals("2014-10-20 19:44:33 UTC",
+                            pageReader.getTimestamp(outputSchema.getColumn(2)).toString());
+                    assertEquals(String.valueOf(4.4),
+                            String.valueOf(pageReader.getDouble(outputSchema.getColumn(3))));
+                    assertEquals("v5", pageReader.getString(outputSchema.getColumn(4)));
+                    assertEquals("2014-10-21 04:44:33 UTC",
+                            pageReader.getTimestamp(outputSchema.getColumn(5)).toString());
+                    assertEquals("2014-10-20 19:44:33 UTC",
+                            pageReader.getTimestamp(outputSchema.getColumn(6)).toString());
+                    assertEquals("[\"Nigel Rees\",\"Evelyn Waugh\",\"Herman Melville\",\"J. R. R. Tolkien\"]",
+                            pageReader.getString(outputSchema.getColumn(7)));
+                    assertEquals("[\"Nigel Rees\",\"Herman Melville\"]",
+                            pageReader.getString(outputSchema.getColumn(8)));
+                    assertEquals("" +
+                                    "[" +
+                                    "{" +
+                                    "\"author\":\"Herman Melville\"," +
+                                    "\"title\":\"Moby Dick\"," +
+                                    "\"isbn\":\"0-553-21311-3\"," +
+                                    "\"price\":8.99" +
+                                    "}," +
+                                    "{" +
+                                    "\"author\":\"J. R. R. Tolkien\"," +
+                                    "\"title\":\"The Lord of the Rings\"," +
+                                    "\"isbn\":\"0-395-19395-8\"," +
+                                    "\"price\":22.99" +
+                                    "}" +
+                                    "]",
+                            pageReader.getString(outputSchema.getColumn(9)));
+                    assertEquals("[\"Sayings of the Century\"]",
+                            pageReader.getString(outputSchema.getColumn(10)));
+                    assertEquals("Herman Melville",
+                            pageReader.getString(outputSchema.getColumn(11)));
+                    assertEquals("v12",
+                            pageReader.getString(outputSchema.getColumn(12)));
+                    assertEquals(c1Data,
+                            pageReader.getString(outputSchema.getColumn(13)));
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testAbortBrokenJsonStringWithNOOPCacheProvider()
+    {
+        String configYaml = "" +
+                "type: expand_json\n" +
+                "json_column_name: _c0\n" +
+                "root: $.\n" +
+                "default_timezone: Asia/Tokyo\n" +
+                "cache_provider: noop\n" +
+                "expanded_columns:\n" +
+                "  - {name: _j0, type: string}\n";
+        ConfigSource config = getConfigFromYaml(configYaml);
+
+        expandJsonFilterPlugin.transaction(config, schema, new Control()
+        {
+            @Override
+            public void run(TaskSource taskSource, Schema outputSchema)
+            {
+                MockPageOutput mockPageOutput = new MockPageOutput();
+                PageOutput pageOutput = expandJsonFilterPlugin.open(taskSource,
+                        schema,
+                        outputSchema,
+                        mockPageOutput);
+
+                String data = getBrokenJsonString();
+                for (Page page : PageTestUtils.buildPage(runtime.getBufferAllocator(),
+                        schema,
+                        data, c1Data)) {
+                    exception.expect(InvalidJsonException.class);
+                    exception.expectMessage("Unexpected End Of File position 12: null");
+                    pageOutput.add(page);
+                }
+
+                pageOutput.finish();
+                pageOutput.close();
+
+                PageReader pageReader = new PageReader(outputSchema);
+
+                for (Page page : mockPageOutput.pages) {
+                    pageReader.setPage(page);
+                    assertEquals("te", pageReader.getString(outputSchema.getColumn(0)));
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testParseNumbersInExponentialNotationWithNOOPCacheProvider()
+    {
+        final String configYaml = "" +
+                "type: expand_json\n" +
+                "json_column_name: _c1\n" +
+                "root: $.\n" +
+                "cache_provider: noop\n" +
+                "expanded_columns:\n" +
+                "  - {name: _j0, type: double}\n" +
+                "  - {name: _j1, type: long}\n";
+        ConfigSource config = getConfigFromYaml(configYaml);
+        final Schema schema = schema("_c1", STRING);
+
+        expandJsonFilterPlugin.transaction(config, schema, new Control()
+        {
+            @Override
+            public void run(TaskSource taskSource, Schema outputSchema)
+            {
+                MockPageOutput mockPageOutput = new MockPageOutput();
+
+                String doubleFloatingPoint = "-1.234e-5";
+                double doubleFixedPoint = -0.00001234; // Use in Asserting.
+                String longFloatingPoint = "12345e3";
+                long longFixedPoint = 12_345_000L; // Use in Asserting.
+
+                String data = String.format(
+                        "{\"_j0\":%s, \"_j1\":%s}",
+                        doubleFloatingPoint,
+                        longFloatingPoint);
+
+                try (PageOutput pageOutput = expandJsonFilterPlugin.open(taskSource, schema, outputSchema, mockPageOutput)) {
+                    for (Page page : PageTestUtils.buildPage(runtime.getBufferAllocator(), schema, data, c1Data)) {
+                        pageOutput.add(page);
+                    }
+
+                    pageOutput.finish();
+                }
+
+                PageReader pageReader = new PageReader(outputSchema);
+
+                for (Page page : mockPageOutput.pages) {
+                    pageReader.setPage(page);
+                    assertEquals(doubleFixedPoint, pageReader.getDouble(outputSchema.getColumn(0)), 0.0);
+                    assertEquals(longFixedPoint, pageReader.getLong(outputSchema.getColumn(1)));
+                }
+            }
+        });
+    }
+
 
     private static Schema schema(Object... nameAndTypes)
     {

--- a/src/test/java/org/embulk/filter/expand_json/TestExpandJsonFilterPlugin.java
+++ b/src/test/java/org/embulk/filter/expand_json/TestExpandJsonFilterPlugin.java
@@ -35,7 +35,12 @@ import java.util.List;
 
 import static org.embulk.filter.expand_json.ExpandJsonFilterPlugin.Control;
 import static org.embulk.filter.expand_json.ExpandJsonFilterPlugin.PluginTask;
-import static org.embulk.spi.type.Types.*;
+import static org.embulk.spi.type.Types.BOOLEAN;
+import static org.embulk.spi.type.Types.DOUBLE;
+import static org.embulk.spi.type.Types.JSON;
+import static org.embulk.spi.type.Types.LONG;
+import static org.embulk.spi.type.Types.STRING;
+import static org.embulk.spi.type.Types.TIMESTAMP;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
# Description
This feature is to make JsonPath cache configurable.
ref. https://github.com/json-path/JsonPath#cache-spi

In some cases, `NOOPCache` improve the performance of this plugin by 3 times.
ref. https://twitter.com/taketakeoe/status/1119143084565024769 (Japanese)

# TODO
- [x] Implementation
- [x] Tests
- [x] Benchmark
- [x] README