### PR TITLE
Catch up with Embulk v0.10.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,17 @@ dependencies {
     compile("com.jayway.jsonpath:json-path:2.4.0") {
         exclude group: "org.slf4j", module: "slf4j-api"
     }
+    compile("org.embulk:embulk-util-json:0.1.0") {
+        // They conflict with embulk-core:0.10.6. They are once excluded here,
+        // and added explicitly with versions exactly the same with embulk-core:0.10.6.
+        exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
+        exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
+        exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
+
+        // It conflicts with embulk-core:0.10.6, and it is expected to stay in embulk-api.
+        // It is just exluded here.
+        exclude group: "org.msgpack", module: "msgpack-core"
+    }
 
     // They are once excluded from transitive dependencies of other dependencies,
     // and added explicitly with versions exactly the same with embulk-core:0.10.5.

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "java"
     id "checkstyle"
     id "maven-publish"
-    id "org.embulk.embulk-plugins" version "0.4.1"
+    id "org.embulk.embulk-plugins" version "0.4.2"
 }
 repositories {
     mavenCentral()
@@ -19,18 +19,28 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compileOnly("org.embulk:embulk-core:0.9.23")
+    compileOnly("org.embulk:embulk-api:0.10.6")
+    compileOnly("org.embulk:embulk-core:0.10.6")
     compile("com.jayway.jsonpath:json-path:2.4.0") {
         exclude group: "org.slf4j", module: "slf4j-api"
     }
+
+    // They are once excluded from transitive dependencies of other dependencies,
+    // and added explicitly with versions exactly the same with embulk-core:0.10.5.
+    compile("com.fasterxml.jackson.core:jackson-annotations:2.6.7")
+    compile("com.fasterxml.jackson.core:jackson-core:2.6.7")
+    compile("com.fasterxml.jackson.core:jackson-databind:2.6.7")
+
     testImplementation "junit:junit:4.+"
-    testImplementation "org.embulk:embulk-core:0.9.23:tests"
-    testImplementation "org.embulk:embulk-core:0.9.23"
+    testImplementation "org.embulk:embulk-core:0.10.6:tests"
+    testImplementation "org.embulk:embulk-core:0.10.6"
+
     // TODO: Remove them.
     // They are now required because the dependency libraries of them are behind sub ClassLoaders.
     // Including them in "testCompile" is a tentative workaround.
-    testImplementation "org.embulk:embulk-deps-buffer:0.9.23"
-    testImplementation "org.embulk:embulk-deps-config:0.9.23"
+    testImplementation "org.embulk:embulk-deps-buffer:0.10.6"
+    testImplementation "org.embulk:embulk-deps-config:0.10.6"
+    testImplementation "org.embulk:embulk-deps-timestamp:0.10.6"
 }
 
 test {
@@ -42,6 +52,14 @@ embulkPlugin {
     mainClass = "org.embulk.filter.expand_json.ExpandJsonFilterPlugin"
     category = "filter"
     type = "expand_json"
+    ignoreConflicts = [
+        // They conflict with embulk-core:0.10.6, but embulk-core will remove them from its dependencies.
+        // They are intentionally included in the plugin's dependencies to keep it working before and after the removal.
+        // Warning messages against them are marked to ignore explicitly here.
+        [ group: "com.fasterxml.jackson.core", module: "jackson-annotations" ],
+        [ group: "com.fasterxml.jackson.core", module: "jackson-core" ],
+        [ group: "com.fasterxml.jackson.core", module: "jackson-databind" ],
+    ]
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
         // It is just exluded here.
         exclude group: "org.msgpack", module: "msgpack-core"
     }
+    compile("org.embulk:embulk-util-timestamp:0.2.0")
 
     // They are once excluded from transitive dependencies of other dependencies,
     // and added explicitly with versions exactly the same with embulk-core:0.10.5.

--- a/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,6 +1,9 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.jayway.jsonpath:json-path:2.4.0
 net.minidev:accessors-smart:1.2
 net.minidev:json-smart:2.3

--- a/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -7,4 +7,5 @@ com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.jayway.jsonpath:json-path:2.4.0
 net.minidev:accessors-smart:1.2
 net.minidev:json-smart:2.3
+org.embulk:embulk-util-json:0.1.0
 org.ow2.asm:asm:5.0.4

--- a/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -8,4 +8,6 @@ com.jayway.jsonpath:json-path:2.4.0
 net.minidev:accessors-smart:1.2
 net.minidev:json-smart:2.3
 org.embulk:embulk-util-json:0.1.0
+org.embulk:embulk-util-rubytime:0.3.0
+org.embulk:embulk-util-timestamp:0.2.0
 org.ow2.asm:asm:5.0.4

--- a/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
@@ -16,7 +16,6 @@ import org.embulk.spi.ColumnConfig;
 import org.embulk.spi.FilterPlugin;
 import org.embulk.spi.PageOutput;
 import org.embulk.spi.Schema;
-import org.embulk.spi.time.TimestampParser;
 import org.embulk.spi.type.Types;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,7 +32,7 @@ public class ExpandJsonFilterPlugin
     private static final Logger logger = LoggerFactory.getLogger(ExpandJsonFilterPlugin.class);
 
     public interface PluginTask
-            extends Task, TimestampParser.Task
+            extends Task
     {
         @Config("json_column_name")
         String getJsonColumnName();
@@ -45,7 +44,19 @@ public class ExpandJsonFilterPlugin
         @Config("expanded_columns")
         List<ColumnConfig> getExpandedColumns();
 
-        // default_timezone option from TimestampParser.Task
+        // default_timezone and other options copied from TimestampParser.Task
+
+        @Config("default_timezone")
+        @ConfigDefault("\"UTC\"")
+        String getDefaultTimeZoneId();
+
+        @Config("default_timestamp_format")
+        @ConfigDefault("\"%Y-%m-%d %H:%M:%S.%N %z\"")
+        String getDefaultTimestampFormat();
+
+        @Config("default_date")
+        @ConfigDefault("\"1970-01-01\"")
+        String getDefaultDate();
 
         @Config("stop_on_invalid_record")
         @ConfigDefault("false")

--- a/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
@@ -14,13 +14,13 @@ import org.embulk.config.Task;
 import org.embulk.config.TaskSource;
 import org.embulk.spi.Column;
 import org.embulk.spi.ColumnConfig;
-import org.embulk.spi.Exec;
 import org.embulk.spi.FilterPlugin;
 import org.embulk.spi.PageOutput;
 import org.embulk.spi.Schema;
 import org.embulk.spi.time.TimestampParser;
 import org.embulk.spi.type.Types;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +30,7 @@ import java.util.Optional;
 public class ExpandJsonFilterPlugin
         implements FilterPlugin
 {
-    private final Logger logger = Exec.getLogger(ExpandJsonFilterPlugin.class);
+    private static final Logger logger = LoggerFactory.getLogger(ExpandJsonFilterPlugin.class);
 
     public interface PluginTask
             extends Task, TimestampParser.Task

--- a/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
@@ -1,6 +1,5 @@
 package org.embulk.filter.expand_json;
 
-import com.google.common.collect.ImmutableList;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.spi.cache.Cache;
 import com.jayway.jsonpath.spi.cache.CacheProvider;
@@ -23,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -100,7 +100,7 @@ public class ExpandJsonFilterPlugin
 
     private Schema buildOutputSchema(PluginTask task, Schema inputSchema)
     {
-        ImmutableList.Builder<Column> builder = ImmutableList.builder();
+        final ArrayList<Column> builder = new ArrayList<>();
 
         int i = 0; // columns index
         for (Column inputColumn: inputSchema.getColumns()) {
@@ -142,7 +142,7 @@ public class ExpandJsonFilterPlugin
             }
         }
 
-        return new Schema(builder.build());
+        return new Schema(Collections.unmodifiableList(builder));
     }
 
     private void validateExpandedColumns(List<ColumnConfig> expandedColumns)

--- a/src/main/java/org/embulk/filter/expand_json/FilteredPageOutput.java
+++ b/src/main/java/org/embulk/filter/expand_json/FilteredPageOutput.java
@@ -26,6 +26,7 @@ import org.embulk.spi.time.TimestampParseException;
 import org.embulk.spi.time.TimestampParser;
 import org.embulk.spi.type.Types;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
@@ -115,7 +116,7 @@ public class FilteredPageOutput
         return new TimestampParser(task, columnOption);
     }
 
-    private final Logger logger = Exec.getLogger(FilteredPageOutput.class);
+    private static final Logger logger = LoggerFactory.getLogger(FilteredPageOutput.class);
     private final boolean stopOnInvalidRecord;
     private final boolean keepExpandingJsonColumn;
     private final List<UnchangedColumn> unchangedColumns;
@@ -238,7 +239,7 @@ public class FilteredPageOutput
         pageBuilder.close();
     }
 
-    
+
     private void setUnchangedColumns() {
         for (UnchangedColumn unchangedColumn : unchangedColumns) {
             Column inputColumn = unchangedColumn.getInputColumn();

--- a/src/main/java/org/embulk/filter/expand_json/FilteredPageOutput.java
+++ b/src/main/java/org/embulk/filter/expand_json/FilteredPageOutput.java
@@ -17,11 +17,11 @@ import org.embulk.spi.PageBuilder;
 import org.embulk.spi.PageOutput;
 import org.embulk.spi.PageReader;
 import org.embulk.spi.Schema;
-import org.embulk.spi.json.JsonParseException;
-import org.embulk.spi.json.JsonParser;
 import org.embulk.spi.time.TimestampParseException;
 import org.embulk.spi.time.TimestampParser;
 import org.embulk.spi.type.Types;
+import org.embulk.util.json.JsonParseException;
+import org.embulk.util.json.JsonParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/test/java/org/embulk/filter/expand_json/TestExpandJsonFilterPlugin.java
+++ b/src/test/java/org/embulk/filter/expand_json/TestExpandJsonFilterPlugin.java
@@ -294,7 +294,7 @@ public class TestExpandJsonFilterPlugin
         PluginTask task = config.loadConfig(PluginTask.class);
 
         assertEquals("$.", task.getRoot());
-        assertEquals("UTC", task.getDefaultTimeZone().getID());
+        assertEquals("UTC", task.getDefaultTimeZoneId());
         assertEquals("%Y-%m-%d %H:%M:%S.%N %z", task.getDefaultTimestampFormat());
         assertEquals(false, task.getStopOnInvalidRecord());
         assertEquals(false, task.getKeepExpandingJsonColumn());


### PR DESCRIPTION
Hi @civitaspo -san,

Thank you for creating and maintaining this awesome plugin!

As we talked at the [meetup](https://www.embulk.org/articles/2020/07/01/meetup-20200709.html), Embulk v0.10, v0.11, and v1.0 would have some incompatibilities from v0.9. This PR is to catch up with the latest v0.10.6. (Yet another PR would come to use `embulk-util-config`.)

I believe it keeps working with Embulk v0.9.23 even after merging this PR.

Can you take a look at this? This PR is broken down into smaller steps per Git commit. I hope it helps easier understanding.