### PR TITLE
Ship v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.5.0 (2020-08-13)
+==================
+- [Enhancement] Run CIs on pull requests from forked repositories.
+  - https://github.com/civitaspo/embulk-filter-expand_json/pull/50
+- [Enhancement] Catch up with Embulk v0.10.6
+  - https://github.com/civitaspo/embulk-filter-expand_json/pull/48
+  - This change will still work correctly with Embulk v0.9.23.
+
 0.4.0 (2020-04-24)
 ==================
 - [Enhancement] Build with the "org.embulk.embulk-plugins" Gradle plugin

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 group = "pro.civitaspo"
-version = "0.4.0"
+version = "0.5.0"
 description = "Expand Json"
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
- [Enhancement] Run CIs on pull requests from forked repositories.
  - https://github.com/civitaspo/embulk-filter-expand_json/pull/50
- [Enhancement] Catch up with Embulk v0.10.6
  - https://github.com/civitaspo/embulk-filter-expand_json/pull/48
  - This change will still work correctly with Embulk v0.9.23.