### PR TITLE
Ship v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.5.2 (2020-08-31)
+==================
+- [Enhancement] Update embulk-util-timestamp to 0.2.1
+  - https://github.com/civitaspo/embulk-filter-expand_json/pull/5
+
 0.5.1 (2020-08-17)
 ==================
 - [Enhancement] Use embulk-util-config:0.1.1 instead of ConfigSource#loadConfig and TaskSource#loadTask

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 group = "pro.civitaspo"
-version = "0.5.1"
+version = "0.5.2"
 description = "Expand Json"
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
0.5.2 (2020-08-31)
==================
- [Enhancement] Update embulk-util-timestamp to 0.2.1
  - https://github.com/civitaspo/embulk-filter-expand_json/pull/5