### PR TITLE
Ship 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.5.3 (2021-06-29)
+==================
+- [Enhancement] Catch up with Embulk v0.10 API/SPI
+  - https://github.com/civitaspo/embulk-filter-expand_json/pull/55
+- [Enhancement] Rename the default branch: master -> main
+  - https://github.com/civitaspo/embulk-filter-expand_json/pull/56
+
 0.5.2 (2020-08-31)
 ==================
 - [Enhancement] Update embulk-util-timestamp to 0.2.1

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 group = "pro.civitaspo"
-version = "0.5.2"
+version = "0.5.3"
 description = "Expand Json"
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
0.5.3 (2021-06-29)
==================
- [Enhancement] Catch up with Embulk v0.10 API/SPI
  - https://github.com/civitaspo/embulk-filter-expand_json/pull/55
- [Enhancement] Rename the default branch: master -> main
  - https://github.com/civitaspo/embulk-filter-expand_json/pull/56