### PR TITLE
setCacheProviderOrIgnore in transaction

### DIFF
--- a/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/expand_json/ExpandJsonFilterPlugin.java
@@ -92,7 +92,7 @@ public class ExpandJsonFilterPlugin
         PluginTask task = configMapper.map(config, PluginTask.class);
 
         // set cache provider
-        task.getCacheProviderName().ifPresent(this::setCacheProvider);
+        task.getCacheProviderName().ifPresent(this::setCacheProviderOrIgnore);
 
         // check if a column specified as json_column_name option exists or not
         Column jsonColumn = inputSchema.lookupColumn(task.getJsonColumnName());


### PR DESCRIPTION
Hi,
we have a service that one plugin instance can run multiple times in the same process. That makes the error `Cache provider must be configured before cache is accessed`, because on the second time the cache was already not null https://code.yawk.at/com.jayway.jsonpath/json-path/2.4.0/com/jayway/jsonpath/spi/cache/CacheProvider.java#14

This change to make safely ignored when cache has already been created before